### PR TITLE
Add getChipId function and examples

### DIFF
--- a/examples/BMP388-ID/BMP388-ID.ino
+++ b/examples/BMP388-ID/BMP388-ID.ino
@@ -1,0 +1,87 @@
+/**
+ * @brief Get Chip-ID of BMP388 using of 107-Arduino-BMP388 library.
+ */
+
+/**************************************************************************************
+ * INCLUDE
+ **************************************************************************************/
+
+#include <SPI.h>
+
+#include <ArduinoBMP388.h>
+
+/**************************************************************************************
+ * CONSTANTS
+ **************************************************************************************/
+
+static int const BMP388_CS_PIN  = 2;
+static int const BMP388_INT_PIN = 6;
+
+/**************************************************************************************
+ * FUNCTION DECLARATION
+ **************************************************************************************/
+
+void    spi_select     ();
+void    spi_deselect   ();
+uint8_t spi_transfer   (uint8_t const);
+void    onSensorData   (double const pressure_hpa, double const temperature_deg);
+
+/**************************************************************************************
+ * GLOBAL VARIABLES
+ **************************************************************************************/
+
+ArduinoBMP388 bmp388(spi_select,
+                     spi_deselect,
+                     spi_transfer,
+                     onSensorData);
+
+/**************************************************************************************
+ * SETUP/LOOP
+ **************************************************************************************/
+
+void setup()
+{
+  uint8_t chip_id;
+  Serial.begin(9600);
+  while(!Serial) { }
+
+  /* Setup SPI access */
+  SPI.begin();
+  pinMode(BMP388_CS_PIN, OUTPUT);
+  digitalWrite(BMP388_CS_PIN, HIGH);
+
+  /* Get BMP388 Chip ID*/
+  Serial.println("The Chip-ID should be 0x50!");
+
+  chip_id=bmp388.getChipId();
+  Serial.print("Chip-ID: 0x");
+  Serial.println(chip_id, HEX);
+}
+
+void loop()
+{
+
+}
+
+/**************************************************************************************
+ * FUNCTION DEFINITION
+ **************************************************************************************/
+
+void spi_select()
+{
+  digitalWrite(BMP388_CS_PIN, LOW);
+}
+
+void spi_deselect()
+{
+  digitalWrite(BMP388_CS_PIN, HIGH);
+}
+
+uint8_t spi_transfer(uint8_t const data)
+{
+  return SPI.transfer(data);
+}
+
+void onSensorData(double const pressure_hpa, double const temperature_deg)
+{
+}

--- a/examples/BMP388-ID/BMP388-ID.ino
+++ b/examples/BMP388-ID/BMP388-ID.ino
@@ -41,7 +41,6 @@ ArduinoBMP388 bmp388(spi_select,
 
 void setup()
 {
-  uint8_t chip_id;
   Serial.begin(9600);
   while(!Serial) { }
 
@@ -53,7 +52,7 @@ void setup()
   /* Get BMP388 Chip ID*/
   Serial.println("The Chip-ID should be 0x50!");
 
-  chip_id=bmp388.getChipId();
+  uint8_t chip_id=bmp388.getChipId();
   Serial.print("Chip-ID: 0x");
   Serial.println(chip_id, HEX);
 }

--- a/examples/BMP388-self-test/BMP388-self-test.ino
+++ b/examples/BMP388-self-test/BMP388-self-test.ino
@@ -1,6 +1,6 @@
 /**
  * @brief BMP388 self-test using 107-Arduino-BMP388 library.
- * 
+ *
  * according to application note https://www.bosch-sensortec.com/media/boschsensortec/downloads/application_notes_1/bst-mps-an006.pdf
  */
 

--- a/examples/BMP388-self-test/BMP388-self-test.ino
+++ b/examples/BMP388-self-test/BMP388-self-test.ino
@@ -71,11 +71,10 @@ void setup()
 
 void loop()
 {
-  uint8_t chip_id;
   /* Get BMP388 Chip ID*/
   Serial.println("Verify Chip-ID");
 
-  chip_id=bmp388.getChipId();
+  uint8_t chip_id=bmp388.getChipId();
   Serial.print("Chip-ID: 0x");
   Serial.println(chip_id, HEX);
   if(chip_id==0x50) Serial.println("Passed!");

--- a/examples/BMP388-self-test/BMP388-self-test.ino
+++ b/examples/BMP388-self-test/BMP388-self-test.ino
@@ -1,0 +1,141 @@
+/**
+ * @brief BMP388 self-test using 107-Arduino-BMP388 library.
+ * 
+ * according to application note https://www.bosch-sensortec.com/media/boschsensortec/downloads/application_notes_1/bst-mps-an006.pdf
+ */
+
+/**************************************************************************************
+ * INCLUDE
+ **************************************************************************************/
+
+#include <SPI.h>
+
+#include <ArduinoBMP388.h>
+
+/**************************************************************************************
+ * CONSTANTS
+ **************************************************************************************/
+
+static int const BMP388_CS_PIN  = 2;
+static int const BMP388_INT_PIN = 6;
+
+/**************************************************************************************
+ * FUNCTION DECLARATION
+ **************************************************************************************/
+
+void    spi_select     ();
+void    spi_deselect   ();
+uint8_t spi_transfer   (uint8_t const);
+void    onExternalEvent();
+void    onSensorData   (double const pressure_hpa, double const temperature_deg);
+
+/**************************************************************************************
+ * GLOBAL VARIABLES
+ **************************************************************************************/
+
+ArduinoBMP388 bmp388(spi_select,
+                     spi_deselect,
+                     spi_transfer,
+                     onSensorData);
+volatile bool measurement_done;
+volatile double measurement_pressure_hpa;
+volatile double measurement_temperature_deg;
+
+/**************************************************************************************
+ * SETUP/LOOP
+ **************************************************************************************/
+
+void setup()
+{
+  Serial.begin(9600);
+  while(!Serial) { }
+
+  /* Setup SPI access */
+  Serial.println("Setup SPI access on Arduino");  
+  SPI.begin();
+  pinMode(BMP388_CS_PIN, OUTPUT);
+  digitalWrite(BMP388_CS_PIN, HIGH);
+  Serial.println("Passed!");  
+
+  /* Attach interrupt handler */
+  Serial.println("Setup interrupt hanlder on Arduino");  
+  pinMode(BMP388_INT_PIN, INPUT_PULLUP);
+  attachInterrupt(digitalPinToInterrupt(BMP388_INT_PIN), onExternalEvent, FALLING);
+  Serial.println("Passed!");  
+
+  /* Configure BMP388 */
+  Serial.println("Initialize BMP388");  
+  bmp388.begin(BMP388::OutputDataRate::ODR_12_5_Hz);
+  Serial.println("Passed!");  
+}
+
+void loop()
+{
+  uint8_t chip_id;
+  /* Get BMP388 Chip ID*/
+  Serial.println("Verify Chip-ID");
+
+  chip_id=bmp388.getChipId();
+  Serial.print("Chip-ID: 0x");
+  Serial.println(chip_id, HEX);
+  if(chip_id==0x50) Serial.println("Passed!");  
+  else Serial.println("Failed!");  
+
+  Serial.println("Verify trimming data");
+  /* not possible now */
+
+  Serial.println("measure temperature and pressure");
+  measurement_done=0;
+  while(measurement_done==0);
+  Serial.println("Passed!");  
+
+  Serial.println("check measurement plausability");
+  Serial.print("temperature:");
+  Serial.println(measurement_temperature_deg);
+  if((measurement_temperature_deg>0)&&(measurement_temperature_deg<40)) Serial.println("Passed!");  
+  else Serial.println("Failed!");  
+  Serial.print("pressure:");
+  Serial.println(measurement_pressure_hpa);
+  if((measurement_pressure_hpa>900)&&(measurement_pressure_hpa<1100)) Serial.println("Passed!");  
+  else Serial.println("Failed!");  
+
+  Serial.println("self-test finished");
+  Serial.println();
+  Serial.println();
+  delay(3000);
+}
+
+/**************************************************************************************
+ * FUNCTION DEFINITION
+ **************************************************************************************/
+
+void spi_select()
+{
+  digitalWrite(BMP388_CS_PIN, LOW);
+}
+
+void spi_deselect()
+{
+  digitalWrite(BMP388_CS_PIN, HIGH);
+}
+
+uint8_t spi_transfer(uint8_t const data)
+{
+  return SPI.transfer(data);
+}
+
+void onExternalEvent()
+{
+  bmp388.onExternalEventHandler();
+}
+
+void onSensorData(double const pressure_hpa, double const temperature_deg)
+{
+//  Serial.print(pressure_hpa);
+//  Serial.print(" hPa / ");
+//  Serial.print(temperature_deg);
+//  Serial.println(" °C");
+  measurement_pressure_hpa=pressure_hpa;
+  measurement_temperature_deg=temperature_deg;
+  measurement_done=1;
+}

--- a/examples/BMP388-self-test/BMP388-self-test.ino
+++ b/examples/BMP388-self-test/BMP388-self-test.ino
@@ -37,9 +37,9 @@ ArduinoBMP388 bmp388(spi_select,
                      spi_deselect,
                      spi_transfer,
                      onSensorData);
-volatile bool measurement_done;
-volatile double measurement_pressure_hpa;
-volatile double measurement_temperature_deg;
+volatile bool measurement_done=false;
+volatile double measurement_pressure_hpa=0.0;
+volatile double measurement_temperature_deg=0.0;
 
 /**************************************************************************************
  * SETUP/LOOP
@@ -85,18 +85,18 @@ void loop()
   /* not possible now */
 
   Serial.println("measure temperature and pressure");
-  measurement_done=0;
-  while(measurement_done==0);
+  measurement_done=false;
+  while(!measurement_done) { };
   Serial.println("Passed!");
 
   Serial.println("check measurement plausibility");
   Serial.print("temperature:");
   Serial.println(measurement_temperature_deg);
-  if((measurement_temperature_deg>0)&&(measurement_temperature_deg<40)) Serial.println("Passed!");
+  if((measurement_temperature_deg>0.0)&&(measurement_temperature_deg<40.0)) Serial.println("Passed!");
   else Serial.println("Failed!");
   Serial.print("pressure:");
   Serial.println(measurement_pressure_hpa);
-  if((measurement_pressure_hpa>900)&&(measurement_pressure_hpa<1100)) Serial.println("Passed!");
+  if((measurement_pressure_hpa>900.0)&&(measurement_pressure_hpa<1100.0)) Serial.println("Passed!");
   else Serial.println("Failed!");
 
   Serial.println("self-test finished");
@@ -131,10 +131,6 @@ void onExternalEvent()
 
 void onSensorData(double const pressure_hpa, double const temperature_deg)
 {
-//  Serial.print(pressure_hpa);
-//  Serial.print(" hPa / ");
-//  Serial.print(temperature_deg);
-//  Serial.println(" °C");
   measurement_pressure_hpa=pressure_hpa;
   measurement_temperature_deg=temperature_deg;
   measurement_done=1;

--- a/examples/BMP388-self-test/BMP388-self-test.ino
+++ b/examples/BMP388-self-test/BMP388-self-test.ino
@@ -51,22 +51,22 @@ void setup()
   while(!Serial) { }
 
   /* Setup SPI access */
-  Serial.println("Setup SPI access on Arduino");  
+  Serial.println("Setup SPI access on Arduino");
   SPI.begin();
   pinMode(BMP388_CS_PIN, OUTPUT);
   digitalWrite(BMP388_CS_PIN, HIGH);
-  Serial.println("Passed!");  
+  Serial.println("Passed!");
 
   /* Attach interrupt handler */
-  Serial.println("Setup interrupt hanlder on Arduino");  
+  Serial.println("Setup interrupt handler on Arduino");
   pinMode(BMP388_INT_PIN, INPUT_PULLUP);
   attachInterrupt(digitalPinToInterrupt(BMP388_INT_PIN), onExternalEvent, FALLING);
-  Serial.println("Passed!");  
+  Serial.println("Passed!");
 
   /* Configure BMP388 */
-  Serial.println("Initialize BMP388");  
+  Serial.println("Initialize BMP388");
   bmp388.begin(BMP388::OutputDataRate::ODR_12_5_Hz);
-  Serial.println("Passed!");  
+  Serial.println("Passed!");
 }
 
 void loop()
@@ -78,8 +78,8 @@ void loop()
   chip_id=bmp388.getChipId();
   Serial.print("Chip-ID: 0x");
   Serial.println(chip_id, HEX);
-  if(chip_id==0x50) Serial.println("Passed!");  
-  else Serial.println("Failed!");  
+  if(chip_id==0x50) Serial.println("Passed!");
+  else Serial.println("Failed!");
 
   Serial.println("Verify trimming data");
   /* not possible now */
@@ -87,17 +87,17 @@ void loop()
   Serial.println("measure temperature and pressure");
   measurement_done=0;
   while(measurement_done==0);
-  Serial.println("Passed!");  
+  Serial.println("Passed!");
 
-  Serial.println("check measurement plausability");
+  Serial.println("check measurement plausibility");
   Serial.print("temperature:");
   Serial.println(measurement_temperature_deg);
-  if((measurement_temperature_deg>0)&&(measurement_temperature_deg<40)) Serial.println("Passed!");  
-  else Serial.println("Failed!");  
+  if((measurement_temperature_deg>0)&&(measurement_temperature_deg<40)) Serial.println("Passed!");
+  else Serial.println("Failed!");
   Serial.print("pressure:");
   Serial.println(measurement_pressure_hpa);
-  if((measurement_pressure_hpa>900)&&(measurement_pressure_hpa<1100)) Serial.println("Passed!");  
-  else Serial.println("Failed!");  
+  if((measurement_pressure_hpa>900)&&(measurement_pressure_hpa<1100)) Serial.println("Passed!");
+  else Serial.println("Failed!");
 
   Serial.println("self-test finished");
   Serial.println();

--- a/src/ArduinoBMP388.cpp
+++ b/src/ArduinoBMP388.cpp
@@ -85,6 +85,11 @@ double ArduinoBMP388::convertPressureToAltitude(double const pressure_hpa)
   return altitude_m;
 }
 
+uint8_t ArduinoBMP388::getChipId(void)
+{
+  return _io.read(Register::CHIP_ID);
+}
+
 /**************************************************************************************
  * PRIVATE MEMBER FUNCTIONS
  **************************************************************************************/

--- a/src/ArduinoBMP388.h
+++ b/src/ArduinoBMP388.h
@@ -46,6 +46,8 @@ public:
 
   static double convertPressureToAltitude(double const pressure_hpa);
 
+  uint8_t getChipId(void);
+
 
 private:
 


### PR DESCRIPTION
Hi @aentinger 
during bring up of my board with the BMP388 I came across some self test function. One is to check the chip ID of the BMP388. So I added this function to the library. I also added two examples. The first shows only the usage of the getChipId function. The second implements the self-test of Bosch application note https://www.bosch-sensortec.com/media/boschsensortec/downloads/application_notes_1/bst-mps-an006.pdf