### PR TITLE
Drop `const` for `get`  to support ArduinoSensorBase:v1.0.4 API change.

### DIFF
--- a/src/107-Arduino-BMP388.h
+++ b/src/107-Arduino-BMP388.h
@@ -58,8 +58,8 @@ public:
 
   static unit::Length convertPressureToAltitude(unit::Pressure const pressure);
 
-  virtual void get      (unit::Pressure & p) const override { p = _pressure; }
-  virtual void get      (unit::Temperature & t) const override { t = _temperature; }
+  virtual void get      (unit::Pressure & p) override { p = _pressure; }
+  virtual void get      (unit::Temperature & t) override { t = _temperature; }
   virtual size_t printTo(Print & p) const override;
 
 


### PR DESCRIPTION
Also see [107-Arduino-Sensor/1.0.4](https://github.com/107-systems/107-Arduino-Sensor/releases/tag/1.0.4).